### PR TITLE
Properly manage signals using a context.

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"github.com/jasondellaluce/experiments/vm-spinner/vmjobs"
 	"os"
+	"os/signal"
 	"runtime"
 	"sync"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -228,6 +230,12 @@ func runApp(c *cli.Context) error {
 		resWg.Done()
 	}()
 
+	// Unlock sm.Acquire() call killing its context on external signals, allowing us
+	// to avoid situations when some images are waiting on sm.Acquire() call,
+	// and current images gets killed by an external signal (managed in vagrant.go),
+	// we proceed to process subsequent images because main thread did not notice anything.
+	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+
 	// prepare sync primitives.
 	// the waitgrup is used to run all the VM in parallel, and to
 	// join with each worker goroutine once their job is finished.
@@ -239,8 +247,13 @@ func runApp(c *cli.Context) error {
 	images := c.StringSlice("image")
 	log.Infof("Running on %v images", images)
 	for i, image := range images {
+		smErr := sm.Acquire(ctx, 1)
+		// Acquire may return non-nil err even if ctx.Done() is triggered
+		if smErr != nil || ctx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
-		sm.Acquire(context.Background(), 1)
 
 		// launch the VM for this image
 		name := fmt.Sprintf("/tmp/%s-%d", image, i)
@@ -261,7 +274,7 @@ func runApp(c *cli.Context) error {
 			}()
 
 			// select the VM outputs
-			channels := RunVirtualMachine(conf)
+			channels := RunVirtualMachine(ctx, conf)
 			for {
 				logger := log.WithFields(log.Fields{"vm": conf.BoxName})
 				select {

--- a/main.go
+++ b/main.go
@@ -46,8 +46,14 @@ func main() {
 					Value: &vmjobs.BpfDefaultImages,
 				},
 				cli.StringFlag{
+					Name:  "forkname",
+					Usage: "libs fork to clone from.",
+					Value: "falcosecurity",
+				},
+				cli.StringFlag{
 					Name:  "commithash",
-					Usage: "falcosecurity/libs commit hash to run the test against.",
+					Usage: "libs commit hash to run the test against.",
+					Value: "master",
 				},
 			},
 		},
@@ -62,8 +68,14 @@ func main() {
 					Value: &vmjobs.KmodDefaultImages,
 				},
 				cli.StringFlag{
+					Name:  "forkname",
+					Usage: "libs fork to clone from.",
+					Value: "falcosecurity",
+				},
+				cli.StringFlag{
 					Name:  "commithash",
-					Usage: "falcosecurity/libs commit hash to run the test against.",
+					Usage: "libs commit hash to run the test against.",
+					Value: "master",
 				},
 			},
 		},

--- a/vmjobs/kmodjob.go
+++ b/vmjobs/kmodjob.go
@@ -54,7 +54,7 @@ func initKmodInfoMap(images []string) map[string]*kmodInfo {
 }
 
 func (j *kmodJob) Cmd() string {
-	return fmt.Sprintf(kmodCmdFmt, j.checkoutCmd)
+	return fmt.Sprintf(kmodCmdFmt, j.forkName, j.commitHash)
 }
 
 func (j *kmodJob) Process(output VMOutput) {

--- a/vmjobs/scripts/bpf_job.sh
+++ b/vmjobs/scripts/bpf_job.sh
@@ -51,8 +51,9 @@ install_deps() {
 }
 
 build_and_run() {
-    git clone https://github.com/falcosecurity/libs.git && cd libs
-	%s
+    git clone https://github.com/%s/libs.git && cd libs
+	  git checkout %s
+
     mkdir build && cd build
 
     if [ "$need_musl" -eq "1" ]

--- a/vmjobs/scripts/kmod_job.sh
+++ b/vmjobs/scripts/kmod_job.sh
@@ -51,8 +51,9 @@ install_deps() {
 }
 
 build_and_run() {
-    git clone https://github.com/falcosecurity/libs.git && cd libs
-	%s
+    git clone https://github.com/%s/libs.git && cd libs
+	  git checkout %s
+
     mkdir build && cd build
 
     if [ "$need_musl" -eq "1" ]


### PR DESCRIPTION
This avoids weird situations where parallelism < len(images), thus a ctrl-c would just stop current images,
but then subsequent images get spawned, instead of quitting.


Moreover, allow to set "forkname" option too for kmod and bpf jobs. 

Signed-off-by: Federico Di Pierro <nierro92@gmail.com>